### PR TITLE
Add Akephalos to Agent Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Tools and extensions that bring AI coding agents directly into development envir
 
 Core components and tooling required to build, run, and scale AI coding agents.
 
+- [Akephalos](https://github.com/sunnja69/akephalos) — Local-first, markdown-first `.akephalos` passport for portable agent preferences, tool notes, rules, project context, and memories across coding agents and MCP-compatible clients via plain files/Git.
 - [OpenAI API](https://platform.openai.com/) — API for accessing advanced language models and tool use capabilities.
 - [vLLM](https://github.com/vllm-project/vllm) — High-performance inference engine for LLMs.
 - [Ollama](https://github.com/ollama/ollama) — Local model runtime for running LLMs on personal machines.


### PR DESCRIPTION
Adds Akephalos to the Agent Infrastructure section.

Akephalos is an early local-first, markdown-first `.akephalos` passport for portable agent context: preferences, tool notes, rules, project context, and durable memories across coding agents and MCP-compatible clients. Sync is via plain files/Git.

Repo/tag checked before submitting: https://github.com/sunnja69/akephalos, tag `v0.1.0`.
