### PR TITLE
Add Before You Build Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Tools and extensions that bring AI coding agents directly into development envir
 
 Core components and tooling required to build, run, and scale AI coding agents.
 
+- [Before You Build Skill](https://github.com/bin1874/before-you-build-skill) — Open-source skill package that helps AI coding agents review product and feature risks before implementation.
 - [OpenAI API](https://platform.openai.com/) — API for accessing advanced language models and tool use capabilities.
 - [vLLM](https://github.com/vllm-project/vllm) — High-performance inference engine for LLMs.
 - [Ollama](https://github.com/ollama/ollama) — Local model runtime for running LLMs on personal machines.


### PR DESCRIPTION
## Summary\n\nAdds Before You Build Skill to the Agent Infrastructure section. It is an open-source SKILL.md package for AI coding agents that reviews product and feature risks before implementation.\n\n## Checklist\n\n- Link points to the public GitHub repository.\n- Description is short and objective.\n- README format matches the existing list style.\n- Ran `git diff --check`.\n- Ran `python3 check_readme_links.py README.md`; the new link returned 200. The script still reports two pre-existing failures: `agentcoder/AgentCoder` 404 and `platform.openai.com` 403.